### PR TITLE
Add WaveSurfer-based frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,9 @@ This app is a browser-based sample extractor built for producers, DJs, and audio
 	•	One-click export – Download your loop as a trimmed WAV file, ready to drop into your DAW, sampler, or set.
 
 Whether you’re chopping samples for hip-hop, prepping loops for a live set, or slicing stems for remixing, this tool makes the process quick, visual, and musical.
+
+## Frontend
+
+A static frontend lives in [`frontend/`](frontend/) using [WaveSurfer.js](https://wavesurfer-js.org/) with Regions and Timeline plugins. It supports drag-and-drop audio upload, loop suggestions, region auditioning, and exporting loops by posting to `/api/export`.
+
+Open `frontend/index.html` in a browser to try it out.

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,102 @@
+let wavesurfer;
+let regionsPlugin;
+let currentFile;
+
+function init() {
+  wavesurfer = WaveSurfer.create({
+    container: '#waveform',
+    waveColor: '#a0a0a0',
+    progressColor: '#555',
+    plugins: [
+      WaveSurfer.regions.create(),
+      WaveSurfer.timeline.create({
+        container: '#timeline'
+      })
+    ]
+  });
+
+  regionsPlugin = wavesurfer.getActivePlugins().regions;
+
+  document.getElementById('play').onclick = () => wavesurfer.play();
+  document.getElementById('pause').onclick = () => wavesurfer.pause();
+  document.getElementById('stop').onclick = () => wavesurfer.stop();
+  document.getElementById('export').onclick = exportSelection;
+
+  const drop = document.getElementById('drop');
+  const fileInput = document.getElementById('fileInput');
+
+  drop.addEventListener('click', () => fileInput.click());
+  drop.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    drop.classList.add('dragover');
+  });
+  drop.addEventListener('dragleave', () => drop.classList.remove('dragover'));
+  drop.addEventListener('drop', (e) => {
+    e.preventDefault();
+    drop.classList.remove('dragover');
+    handleFiles(e.dataTransfer.files);
+  });
+  fileInput.addEventListener('change', (e) => handleFiles(e.target.files));
+
+  wavesurfer.on('ready', showSuggestedLoops);
+  regionsPlugin.on('region-click', (region, e) => {
+    e.stopPropagation();
+    region.playLoop();
+  });
+}
+
+function handleFiles(files) {
+  if (!files.length) return;
+  const file = files[0];
+  if (!file.type.startsWith('audio')) return;
+  currentFile = file;
+  wavesurfer.loadBlob(file);
+}
+
+function showSuggestedLoops() {
+  regionsPlugin.clearRegions();
+  const duration = wavesurfer.getDuration();
+  const loops = [
+    { start: 0, end: Math.min(2, duration) },
+    { start: Math.max(0, duration / 2 - 1), end: Math.min(duration, duration / 2 + 1) }
+  ];
+  loops.forEach(({ start, end }) =>
+    regionsPlugin.addRegion({
+      start,
+      end,
+      color: 'rgba(0, 255, 0, 0.1)',
+      drag: false,
+      resize: false
+    })
+  );
+}
+
+async function exportSelection() {
+  if (!currentFile) return;
+  const loops = Object.values(regionsPlugin.regions).map((r) => ({
+    start: r.start,
+    end: r.end
+  }));
+  const formData = new FormData();
+  formData.append('file', currentFile);
+  formData.append('loops', JSON.stringify(loops));
+
+  const res = await fetch('/api/export', {
+    method: 'POST',
+    body: formData
+  });
+
+  if (res.ok) {
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'export.wav';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>SplicePoint</title>
+  <link rel="stylesheet" href="styles.css" />
+  <script src="https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.min.js"></script>
+  <script src="https://unpkg.com/wavesurfer.js@7/dist/plugins/regions.min.js"></script>
+  <script src="https://unpkg.com/wavesurfer.js@7/dist/plugins/timeline.min.js"></script>
+</head>
+<body>
+  <div id="drop" class="drop">
+    Drop audio here or click to upload
+    <input type="file" id="fileInput" accept="audio/*" hidden />
+  </div>
+  <div id="waveform"></div>
+  <div id="timeline"></div>
+  <div class="controls">
+    <button id="play">Play</button>
+    <button id="pause">Pause</button>
+    <button id="stop">Stop</button>
+    <button id="export">Export</button>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,32 @@
+body {
+  font-family: sans-serif;
+  margin: 20px;
+}
+
+#waveform {
+  height: 128px;
+  margin-top: 10px;
+}
+
+#timeline {
+  height: 20px;
+}
+
+.drop {
+  border: 2px dashed #aaa;
+  padding: 20px;
+  text-align: center;
+  cursor: pointer;
+}
+
+.drop.dragover {
+  border-color: #555;
+}
+
+.controls {
+  margin-top: 10px;
+}
+
+.controls button {
+  margin-right: 5px;
+}


### PR DESCRIPTION
## Summary
- create static frontend using WaveSurfer.js with Regions and Timeline plugins
- enable drag-and-drop audio upload, suggested loop overlays, playback, and region auditioning
- add Export button posting to `/api/export` to download WAV

## Testing
- `node --check frontend/app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7eddc981c832d99ade39e6fe59414