### PR TITLE
Add Spring Boot backend with loop export API

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+/mvnw text eol=lf
+*.cmd text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+HELP.md
+target/
+.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # SplicePoint
 This app is a browser-based sample extractor built for producers, DJs, and audio tinkerers who want fast, reliable loops without digging through waveforms manually.
-	•	Upload any track – MP3, WAV, AIFF, you name it.
-	•	Automatic analysis – Detects BPM, beat grid, and suggests the cleanest loop points with confidence scores.
-	•	Interactive waveform preview – Drag start/end markers or snap to the beat grid for bar-perfect precision.
-	•	Loop auditioning – Instantly play and loop your selection right in the browser.
-	•	One-click export – Download your loop as a trimmed WAV file, ready to drop into your DAW, sampler, or set.
+        •       Upload any track – MP3, WAV, AIFF, you name it.
+        •       Automatic analysis – Detects BPM, beat grid, and suggests the cleanest loop points with confidence scores.
+        •       Interactive waveform preview – Drag start/end markers or snap to the beat grid for bar-perfect precision.
+        •       Loop auditioning – Instantly play and loop your selection right in the browser.
+        •       One-click export – Download your loop as a trimmed WAV file, ready to drop into your DAW, sampler, or set.
 
 Whether you’re chopping samples for hip-hop, prepping loops for a live set, or slicing stems for remixing, this tool makes the process quick, visual, and musical.
 
@@ -13,3 +13,16 @@ Whether you’re chopping samples for hip-hop, prepping loops for a live set, or
 A static frontend lives in [`frontend/`](frontend/) using [WaveSurfer.js](https://wavesurfer-js.org/) with Regions and Timeline plugins. It supports drag-and-drop audio upload, loop suggestions, region auditioning, and exporting loops by posting to `/api/export`.
 
 Open `frontend/index.html` in a browser to try it out.
+
+## Backend
+
+The backend lives in [`backend/`](backend/). It's a Spring Boot application exposing two endpoints:
+
+- `POST /api/extract` – returns placeholder BPM, duration, and loop suggestions for an uploaded file.
+- `POST /api/export` – trims the uploaded audio between `start` and `end` seconds and returns a WAV file.
+
+Run it with:
+
+```
+./backend/mvnw spring-boot:run
+```

--- a/README.md
+++ b/README.md
@@ -1,28 +1,129 @@
 # SplicePoint
-This app is a browser-based sample extractor built for producers, DJs, and audio tinkerers who want fast, reliable loops without digging through waveforms manually.
-        •       Upload any track – MP3, WAV, AIFF, you name it.
-        •       Automatic analysis – Detects BPM, beat grid, and suggests the cleanest loop points with confidence scores.
-        •       Interactive waveform preview – Drag start/end markers or snap to the beat grid for bar-perfect precision.
-        •       Loop auditioning – Instantly play and loop your selection right in the browser.
-        •       One-click export – Download your loop as a trimmed WAV file, ready to drop into your DAW, sampler, or set.
 
-Whether you’re chopping samples for hip-hop, prepping loops for a live set, or slicing stems for remixing, this tool makes the process quick, visual, and musical.
+SplicePoint is a browser-based sample extractor for producers, DJs, remixers, and audio tinkerers who want fast, reliable loops without digging through waveforms manually.
+
+## Current Phase 1 Goal
+
+Upload audio, inspect candidate splice regions, audition loops, adjust the selected region, and export a usable WAV slice.
+
+SplicePoint is not trying to become a full DAW. It is a focused loop utility: quick in, clean loop out.
+
+## Features
+
+- Upload browser-supported audio through the frontend.
+- Render an interactive waveform with WaveSurfer.js.
+- Display candidate loop regions returned by the backend.
+- Drag and resize regions in the waveform.
+- Audition a loop by clicking a region or candidate card.
+- Export the selected region as a WAV file.
+- Return Phase 1 analysis metadata: duration, sample rate, channel count, heuristic candidates, confidence scores, and warnings.
 
 ## Frontend
 
-A static frontend lives in [`frontend/`](frontend/) using [WaveSurfer.js](https://wavesurfer-js.org/) with Regions and Timeline plugins. It supports drag-and-drop audio upload, loop suggestions, region auditioning, and exporting loops by posting to `/api/export`.
+The static frontend lives in [`frontend/`](frontend/) and uses WaveSurfer.js with Regions and Timeline plugins.
 
-Open `frontend/index.html` in a browser to try it out.
+When opened directly from disk, the frontend points API calls to `http://localhost:8080`. When served from another origin, it uses same-origin API paths.
+
+Open this file in a browser for local Phase 1 testing:
+
+```text
+frontend/index.html
+```
 
 ## Backend
 
-The backend lives in [`backend/`](backend/). It's a Spring Boot application exposing two endpoints:
+The backend lives in [`backend/`](backend/). It is a Spring Boot application that exposes the Phase 1 audio API.
 
-- `POST /api/extract` – returns placeholder BPM, duration, and loop suggestions for an uploaded file.
-- `POST /api/export` – trims the uploaded audio between `start` and `end` seconds and returns a WAV file.
+### Endpoints
 
-Run it with:
+#### `GET /api/health`
 
+Returns backend status and engine identity.
+
+#### `POST /api/extract`
+
+Accepts multipart form data:
+
+```text
+file=<audio file>
 ```
+
+Returns JSON with:
+
+- file name
+- content type
+- byte size
+- duration seconds
+- sample rate
+- channel count
+- BPM estimate placeholder fields
+- engine status
+- loop candidates
+- warning messages
+
+Loop candidates include:
+
+- `start`
+- `end`
+- `duration`
+- `confidence`
+- `label`
+- `reasons`
+
+#### `POST /api/export`
+
+Accepts multipart form data:
+
+```text
+file=<audio file>
+start=<seconds>
+end=<seconds>
+fadeMs=<optional fade length, default 5>
+```
+
+Returns a downloadable `audio/wav` response.
+
+## Run Backend
+
+From the repo root:
+
+```bash
 ./backend/mvnw spring-boot:run
 ```
+
+On Windows PowerShell:
+
+```powershell
+.\backend\mvnw.cmd spring-boot:run
+```
+
+The backend defaults to:
+
+```text
+http://localhost:8080
+```
+
+## Test Backend
+
+```bash
+./backend/mvnw test
+```
+
+The first run needs network access so Maven can resolve Spring Boot dependencies.
+
+## Phase 1 Format Note
+
+The backend currently uses Java Sound for decoding and WAV export. WAV and AIFF are the safest local test formats. Broader MP3 or codec-heavy support should be treated as a later backend-engine upgrade, likely through FFmpeg or another dedicated audio stack.
+
+## Development Direction
+
+The current implementation keeps the frontend and backend contract simple:
+
+```text
+upload file
+→ /api/extract returns loop candidates
+→ user selects or edits region
+→ /api/export returns selected WAV slice
+```
+
+Future roadmap work should improve the analysis engine without changing that basic workflow unless absolutely necessary.

--- a/backend/.mvn/wrapper/maven-wrapper.properties
+++ b/backend/.mvn/wrapper/maven-wrapper.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+wrapperVersion=3.3.2
+distributionType=only-script
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip

--- a/backend/mvnw
+++ b/backend/mvnw
@@ -1,0 +1,259 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+# ----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
+# Apache Maven Wrapper startup batch script, version 3.3.2
+#
+# Optional ENV vars
+# -----------------
+#   JAVA_HOME - location of a JDK home dir, required when download maven via java source
+#   MVNW_REPOURL - repo url base for downloading maven distribution
+#   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+#   MVNW_VERBOSE - true: enable verbose log; debug: trace the mvnw script; others: silence the output
+# ----------------------------------------------------------------------------
+
+set -euf
+[ "${MVNW_VERBOSE-}" != debug ] || set -x
+
+# OS specific support.
+native_path() { printf %s\\n "$1"; }
+case "$(uname)" in
+CYGWIN* | MINGW*)
+  [ -z "${JAVA_HOME-}" ] || JAVA_HOME="$(cygpath --unix "$JAVA_HOME")"
+  native_path() { cygpath --path --windows "$1"; }
+  ;;
+esac
+
+# set JAVACMD and JAVACCMD
+set_java_home() {
+  # For Cygwin and MinGW, ensure paths are in Unix format before anything is touched
+  if [ -n "${JAVA_HOME-}" ]; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ]; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+      JAVACCMD="$JAVA_HOME/jre/sh/javac"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+      JAVACCMD="$JAVA_HOME/bin/javac"
+
+      if [ ! -x "$JAVACMD" ] || [ ! -x "$JAVACCMD" ]; then
+        echo "The JAVA_HOME environment variable is not defined correctly, so mvnw cannot run." >&2
+        echo "JAVA_HOME is set to \"$JAVA_HOME\", but \"\$JAVA_HOME/bin/java\" or \"\$JAVA_HOME/bin/javac\" does not exist." >&2
+        return 1
+      fi
+    fi
+  else
+    JAVACMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v java
+    )" || :
+    JAVACCMD="$(
+      'set' +e
+      'unset' -f command 2>/dev/null
+      'command' -v javac
+    )" || :
+
+    if [ ! -x "${JAVACMD-}" ] || [ ! -x "${JAVACCMD-}" ]; then
+      echo "The java/javac command does not exist in PATH nor is JAVA_HOME set, so mvnw cannot run." >&2
+      return 1
+    fi
+  fi
+}
+
+# hash string like Java String::hashCode
+hash_string() {
+  str="${1:-}" h=0
+  while [ -n "$str" ]; do
+    char="${str%"${str#?}"}"
+    h=$(((h * 31 + $(LC_CTYPE=C printf %d "'$char")) % 4294967296))
+    str="${str#?}"
+  done
+  printf %x\\n $h
+}
+
+verbose() { :; }
+[ "${MVNW_VERBOSE-}" != true ] || verbose() { printf %s\\n "${1-}"; }
+
+die() {
+  printf %s\\n "$1" >&2
+  exit 1
+}
+
+trim() {
+  # MWRAPPER-139:
+  #   Trims trailing and leading whitespace, carriage returns, tabs, and linefeeds.
+  #   Needed for removing poorly interpreted newline sequences when running in more
+  #   exotic environments such as mingw bash on Windows.
+  printf "%s" "${1}" | tr -d '[:space:]'
+}
+
+# parse distributionUrl and optional distributionSha256Sum, requires .mvn/wrapper/maven-wrapper.properties
+while IFS="=" read -r key value; do
+  case "${key-}" in
+  distributionUrl) distributionUrl=$(trim "${value-}") ;;
+  distributionSha256Sum) distributionSha256Sum=$(trim "${value-}") ;;
+  esac
+done <"${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+[ -n "${distributionUrl-}" ] || die "cannot read distributionUrl property in ${0%/*}/.mvn/wrapper/maven-wrapper.properties"
+
+case "${distributionUrl##*/}" in
+maven-mvnd-*bin.*)
+  MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/
+  case "${PROCESSOR_ARCHITECTURE-}${PROCESSOR_ARCHITEW6432-}:$(uname -a)" in
+  *AMD64:CYGWIN* | *AMD64:MINGW*) distributionPlatform=windows-amd64 ;;
+  :Darwin*x86_64) distributionPlatform=darwin-amd64 ;;
+  :Darwin*arm64) distributionPlatform=darwin-aarch64 ;;
+  :Linux*x86_64*) distributionPlatform=linux-amd64 ;;
+  *)
+    echo "Cannot detect native platform for mvnd on $(uname)-$(uname -m), use pure java version" >&2
+    distributionPlatform=linux-amd64
+    ;;
+  esac
+  distributionUrl="${distributionUrl%-bin.*}-$distributionPlatform.zip"
+  ;;
+maven-mvnd-*) MVN_CMD=mvnd.sh _MVNW_REPO_PATTERN=/maven/mvnd/ ;;
+*) MVN_CMD="mvn${0##*/mvnw}" _MVNW_REPO_PATTERN=/org/apache/maven/ ;;
+esac
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+[ -z "${MVNW_REPOURL-}" ] || distributionUrl="$MVNW_REPOURL$_MVNW_REPO_PATTERN${distributionUrl#*"$_MVNW_REPO_PATTERN"}"
+distributionUrlName="${distributionUrl##*/}"
+distributionUrlNameMain="${distributionUrlName%.*}"
+distributionUrlNameMain="${distributionUrlNameMain%-bin}"
+MAVEN_USER_HOME="${MAVEN_USER_HOME:-${HOME}/.m2}"
+MAVEN_HOME="${MAVEN_USER_HOME}/wrapper/dists/${distributionUrlNameMain-}/$(hash_string "$distributionUrl")"
+
+exec_maven() {
+  unset MVNW_VERBOSE MVNW_USERNAME MVNW_PASSWORD MVNW_REPOURL || :
+  exec "$MAVEN_HOME/bin/$MVN_CMD" "$@" || die "cannot exec $MAVEN_HOME/bin/$MVN_CMD"
+}
+
+if [ -d "$MAVEN_HOME" ]; then
+  verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  exec_maven "$@"
+fi
+
+case "${distributionUrl-}" in
+*?-bin.zip | *?maven-mvnd-?*-?*.zip) ;;
+*) die "distributionUrl is not valid, must match *-bin.zip or maven-mvnd-*.zip, but found '${distributionUrl-}'" ;;
+esac
+
+# prepare tmp dir
+if TMP_DOWNLOAD_DIR="$(mktemp -d)" && [ -d "$TMP_DOWNLOAD_DIR" ]; then
+  clean() { rm -rf -- "$TMP_DOWNLOAD_DIR"; }
+  trap clean HUP INT TERM EXIT
+else
+  die "cannot create temp dir"
+fi
+
+mkdir -p -- "${MAVEN_HOME%/*}"
+
+# Download and Install Apache Maven
+verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+verbose "Downloading from: $distributionUrl"
+verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+# select .zip or .tar.gz
+if ! command -v unzip >/dev/null; then
+  distributionUrl="${distributionUrl%.zip}.tar.gz"
+  distributionUrlName="${distributionUrl##*/}"
+fi
+
+# verbose opt
+__MVNW_QUIET_WGET=--quiet __MVNW_QUIET_CURL=--silent __MVNW_QUIET_UNZIP=-q __MVNW_QUIET_TAR=''
+[ "${MVNW_VERBOSE-}" != true ] || __MVNW_QUIET_WGET='' __MVNW_QUIET_CURL='' __MVNW_QUIET_UNZIP='' __MVNW_QUIET_TAR=v
+
+# normalize http auth
+case "${MVNW_PASSWORD:+has-password}" in
+'') MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+has-password) [ -n "${MVNW_USERNAME-}" ] || MVNW_USERNAME='' MVNW_PASSWORD='' ;;
+esac
+
+if [ -z "${MVNW_USERNAME-}" ] && command -v wget >/dev/null; then
+  verbose "Found wget ... using wget"
+  wget ${__MVNW_QUIET_WGET:+"$__MVNW_QUIET_WGET"} "$distributionUrl" -O "$TMP_DOWNLOAD_DIR/$distributionUrlName" || die "wget: Failed to fetch $distributionUrl"
+elif [ -z "${MVNW_USERNAME-}" ] && command -v curl >/dev/null; then
+  verbose "Found curl ... using curl"
+  curl ${__MVNW_QUIET_CURL:+"$__MVNW_QUIET_CURL"} -f -L -o "$TMP_DOWNLOAD_DIR/$distributionUrlName" "$distributionUrl" || die "curl: Failed to fetch $distributionUrl"
+elif set_java_home; then
+  verbose "Falling back to use Java to download"
+  javaSource="$TMP_DOWNLOAD_DIR/Downloader.java"
+  targetZip="$TMP_DOWNLOAD_DIR/$distributionUrlName"
+  cat >"$javaSource" <<-END
+	public class Downloader extends java.net.Authenticator
+	{
+	  protected java.net.PasswordAuthentication getPasswordAuthentication()
+	  {
+	    return new java.net.PasswordAuthentication( System.getenv( "MVNW_USERNAME" ), System.getenv( "MVNW_PASSWORD" ).toCharArray() );
+	  }
+	  public static void main( String[] args ) throws Exception
+	  {
+	    setDefault( new Downloader() );
+	    java.nio.file.Files.copy( java.net.URI.create( args[0] ).toURL().openStream(), java.nio.file.Paths.get( args[1] ).toAbsolutePath().normalize() );
+	  }
+	}
+	END
+  # For Cygwin/MinGW, switch paths to Windows format before running javac and java
+  verbose " - Compiling Downloader.java ..."
+  "$(native_path "$JAVACCMD")" "$(native_path "$javaSource")" || die "Failed to compile Downloader.java"
+  verbose " - Running Downloader.java ..."
+  "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
+fi
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+if [ -n "${distributionSha256Sum-}" ]; then
+  distributionSha256Result=false
+  if [ "$MVN_CMD" = mvnd.sh ]; then
+    echo "Checksum validation is not supported for maven-mvnd." >&2
+    echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  elif command -v sha256sum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  elif command -v shasum >/dev/null; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c >/dev/null 2>&1; then
+      distributionSha256Result=true
+    fi
+  else
+    echo "Checksum validation was requested but neither 'sha256sum' or 'shasum' are available." >&2
+    echo "Please install either command, or disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
+    exit 1
+  fi
+  if [ $distributionSha256Result = false ]; then
+    echo "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised." >&2
+    echo "If you updated your Maven version, you need to update the specified distributionSha256Sum property." >&2
+    exit 1
+  fi
+fi
+
+# unzip and move
+if command -v unzip >/dev/null; then
+  unzip ${__MVNW_QUIET_UNZIP:+"$__MVNW_QUIET_UNZIP"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -d "$TMP_DOWNLOAD_DIR" || die "failed to unzip"
+else
+  tar xzf${__MVNW_QUIET_TAR:+"$__MVNW_QUIET_TAR"} "$TMP_DOWNLOAD_DIR/$distributionUrlName" -C "$TMP_DOWNLOAD_DIR" || die "failed to untar"
+fi
+printf %s\\n "$distributionUrl" >"$TMP_DOWNLOAD_DIR/$distributionUrlNameMain/mvnw.url"
+mv -- "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" "$MAVEN_HOME" || [ -d "$MAVEN_HOME" ] || die "fail to move MAVEN_HOME"
+
+clean || :
+exec_maven "$@"

--- a/backend/mvnw.cmd
+++ b/backend/mvnw.cmd
@@ -1,0 +1,149 @@
+<# : batch portion
+@REM ----------------------------------------------------------------------------
+@REM Licensed to the Apache Software Foundation (ASF) under one
+@REM or more contributor license agreements.  See the NOTICE file
+@REM distributed with this work for additional information
+@REM regarding copyright ownership.  The ASF licenses this file
+@REM to you under the Apache License, Version 2.0 (the
+@REM "License"); you may not use this file except in compliance
+@REM with the License.  You may obtain a copy of the License at
+@REM
+@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM
+@REM Unless required by applicable law or agreed to in writing,
+@REM software distributed under the License is distributed on an
+@REM "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+@REM KIND, either express or implied.  See the License for the
+@REM specific language governing permissions and limitations
+@REM under the License.
+@REM ----------------------------------------------------------------------------
+
+@REM ----------------------------------------------------------------------------
+@REM Apache Maven Wrapper startup batch script, version 3.3.2
+@REM
+@REM Optional ENV vars
+@REM   MVNW_REPOURL - repo url base for downloading maven distribution
+@REM   MVNW_USERNAME/MVNW_PASSWORD - user and password for downloading maven
+@REM   MVNW_VERBOSE - true: enable verbose log; others: silence the output
+@REM ----------------------------------------------------------------------------
+
+@IF "%__MVNW_ARG0_NAME__%"=="" (SET __MVNW_ARG0_NAME__=%~nx0)
+@SET __MVNW_CMD__=
+@SET __MVNW_ERROR__=
+@SET __MVNW_PSMODULEP_SAVE=%PSModulePath%
+@SET PSModulePath=
+@FOR /F "usebackq tokens=1* delims==" %%A IN (`powershell -noprofile "& {$scriptDir='%~dp0'; $script='%__MVNW_ARG0_NAME__%'; icm -ScriptBlock ([Scriptblock]::Create((Get-Content -Raw '%~f0'))) -NoNewScope}"`) DO @(
+  IF "%%A"=="MVN_CMD" (set __MVNW_CMD__=%%B) ELSE IF "%%B"=="" (echo %%A) ELSE (echo %%A=%%B)
+)
+@SET PSModulePath=%__MVNW_PSMODULEP_SAVE%
+@SET __MVNW_PSMODULEP_SAVE=
+@SET __MVNW_ARG0_NAME__=
+@SET MVNW_USERNAME=
+@SET MVNW_PASSWORD=
+@IF NOT "%__MVNW_CMD__%"=="" (%__MVNW_CMD__% %*)
+@echo Cannot start maven from wrapper >&2 && exit /b 1
+@GOTO :EOF
+: end batch / begin powershell #>
+
+$ErrorActionPreference = "Stop"
+if ($env:MVNW_VERBOSE -eq "true") {
+  $VerbosePreference = "Continue"
+}
+
+# calculate distributionUrl, requires .mvn/wrapper/maven-wrapper.properties
+$distributionUrl = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionUrl
+if (!$distributionUrl) {
+  Write-Error "cannot read distributionUrl property in $scriptDir/.mvn/wrapper/maven-wrapper.properties"
+}
+
+switch -wildcard -casesensitive ( $($distributionUrl -replace '^.*/','') ) {
+  "maven-mvnd-*" {
+    $USE_MVND = $true
+    $distributionUrl = $distributionUrl -replace '-bin\.[^.]*$',"-windows-amd64.zip"
+    $MVN_CMD = "mvnd.cmd"
+    break
+  }
+  default {
+    $USE_MVND = $false
+    $MVN_CMD = $script -replace '^mvnw','mvn'
+    break
+  }
+}
+
+# apply MVNW_REPOURL and calculate MAVEN_HOME
+# maven home pattern: ~/.m2/wrapper/dists/{apache-maven-<version>,maven-mvnd-<version>-<platform>}/<hash>
+if ($env:MVNW_REPOURL) {
+  $MVNW_REPO_PATTERN = if ($USE_MVND) { "/org/apache/maven/" } else { "/maven/mvnd/" }
+  $distributionUrl = "$env:MVNW_REPOURL$MVNW_REPO_PATTERN$($distributionUrl -replace '^.*'+$MVNW_REPO_PATTERN,'')"
+}
+$distributionUrlName = $distributionUrl -replace '^.*/',''
+$distributionUrlNameMain = $distributionUrlName -replace '\.[^.]*$','' -replace '-bin$',''
+$MAVEN_HOME_PARENT = "$HOME/.m2/wrapper/dists/$distributionUrlNameMain"
+if ($env:MAVEN_USER_HOME) {
+  $MAVEN_HOME_PARENT = "$env:MAVEN_USER_HOME/wrapper/dists/$distributionUrlNameMain"
+}
+$MAVEN_HOME_NAME = ([System.Security.Cryptography.MD5]::Create().ComputeHash([byte[]][char[]]$distributionUrl) | ForEach-Object {$_.ToString("x2")}) -join ''
+$MAVEN_HOME = "$MAVEN_HOME_PARENT/$MAVEN_HOME_NAME"
+
+if (Test-Path -Path "$MAVEN_HOME" -PathType Container) {
+  Write-Verbose "found existing MAVEN_HOME at $MAVEN_HOME"
+  Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"
+  exit $?
+}
+
+if (! $distributionUrlNameMain -or ($distributionUrlName -eq $distributionUrlNameMain)) {
+  Write-Error "distributionUrl is not valid, must end with *-bin.zip, but found $distributionUrl"
+}
+
+# prepare tmp dir
+$TMP_DOWNLOAD_DIR_HOLDER = New-TemporaryFile
+$TMP_DOWNLOAD_DIR = New-Item -Itemtype Directory -Path "$TMP_DOWNLOAD_DIR_HOLDER.dir"
+$TMP_DOWNLOAD_DIR_HOLDER.Delete() | Out-Null
+trap {
+  if ($TMP_DOWNLOAD_DIR.Exists) {
+    try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+    catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+  }
+}
+
+New-Item -Itemtype Directory -Path "$MAVEN_HOME_PARENT" -Force | Out-Null
+
+# Download and Install Apache Maven
+Write-Verbose "Couldn't find MAVEN_HOME, downloading and installing it ..."
+Write-Verbose "Downloading from: $distributionUrl"
+Write-Verbose "Downloading to: $TMP_DOWNLOAD_DIR/$distributionUrlName"
+
+$webclient = New-Object System.Net.WebClient
+if ($env:MVNW_USERNAME -and $env:MVNW_PASSWORD) {
+  $webclient.Credentials = New-Object System.Net.NetworkCredential($env:MVNW_USERNAME, $env:MVNW_PASSWORD)
+}
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+$webclient.DownloadFile($distributionUrl, "$TMP_DOWNLOAD_DIR/$distributionUrlName") | Out-Null
+
+# If specified, validate the SHA-256 sum of the Maven distribution zip file
+$distributionSha256Sum = (Get-Content -Raw "$scriptDir/.mvn/wrapper/maven-wrapper.properties" | ConvertFrom-StringData).distributionSha256Sum
+if ($distributionSha256Sum) {
+  if ($USE_MVND) {
+    Write-Error "Checksum validation is not supported for maven-mvnd. `nPlease disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties."
+  }
+  Import-Module $PSHOME\Modules\Microsoft.PowerShell.Utility -Function Get-FileHash
+  if ((Get-FileHash "$TMP_DOWNLOAD_DIR/$distributionUrlName" -Algorithm SHA256).Hash.ToLower() -ne $distributionSha256Sum) {
+    Write-Error "Error: Failed to validate Maven distribution SHA-256, your Maven distribution might be compromised. If you updated your Maven version, you need to update the specified distributionSha256Sum property."
+  }
+}
+
+# unzip and move
+Expand-Archive "$TMP_DOWNLOAD_DIR/$distributionUrlName" -DestinationPath "$TMP_DOWNLOAD_DIR" | Out-Null
+Rename-Item -Path "$TMP_DOWNLOAD_DIR/$distributionUrlNameMain" -NewName $MAVEN_HOME_NAME | Out-Null
+try {
+  Move-Item -Path "$TMP_DOWNLOAD_DIR/$MAVEN_HOME_NAME" -Destination $MAVEN_HOME_PARENT | Out-Null
+} catch {
+  if (! (Test-Path -Path "$MAVEN_HOME" -PathType Container)) {
+    Write-Error "fail to move MAVEN_HOME"
+  }
+} finally {
+  try { Remove-Item $TMP_DOWNLOAD_DIR -Recurse -Force | Out-Null }
+  catch { Write-Warning "Cannot remove $TMP_DOWNLOAD_DIR" }
+}
+
+Write-Output "MVN_CMD=$MAVEN_HOME/bin/$MVN_CMD"

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.springframework.boot</groupId>
+		<artifactId>spring-boot-starter-parent</artifactId>
+		<version>3.5.5</version>
+		<relativePath/> <!-- lookup parent from repository -->
+	</parent>
+	<groupId>com.example</groupId>
+	<artifactId>backend</artifactId>
+	<version>0.0.1-SNAPSHOT</version>
+	<name>backend</name>
+	<description>Demo project for Spring Boot</description>
+	<url/>
+	<licenses>
+		<license/>
+	</licenses>
+	<developers>
+		<developer/>
+	</developers>
+	<scm>
+		<connection/>
+		<developerConnection/>
+		<tag/>
+		<url/>
+	</scm>
+	<properties>
+		<java.version>21</java.version>
+	</properties>
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.springframework.boot</groupId>
+				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/backend/src/main/java/com/example/backend/AudioController.java
+++ b/backend/src/main/java/com/example/backend/AudioController.java
@@ -1,0 +1,60 @@
+package com.example.backend;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.sound.sampled.*;
+import java.io.*;
+import java.util.*;
+
+@RestController
+@RequestMapping("/api")
+public class AudioController {
+
+    @PostMapping("/extract")
+    public Map<String, Object> extract(@RequestParam("file") MultipartFile file) throws Exception {
+        Map<String, Object> result = new HashMap<>();
+        try (AudioInputStream ais = AudioSystem.getAudioInputStream(file.getInputStream())) {
+            AudioFormat format = ais.getFormat();
+            long frames = ais.getFrameLength();
+            double duration = frames / format.getFrameRate();
+            result.put("bpm", 120); // placeholder until analysis added
+            result.put("duration", duration);
+            double loopLen = Math.min(2.0, duration);
+            List<Map<String, Double>> loops = new ArrayList<>();
+            loops.add(Map.of("start", 0.0, "end", loopLen));
+            double start2 = Math.max(0.0, duration / 2 - loopLen / 2);
+            loops.add(Map.of("start", start2, "end", Math.min(duration, start2 + loopLen)));
+            result.put("loops", loops);
+        }
+        return result;
+    }
+
+    @PostMapping("/export")
+    public ResponseEntity<byte[]> export(@RequestParam("file") MultipartFile file,
+                                         @RequestParam("start") double start,
+                                         @RequestParam("end") double end) throws Exception {
+        byte[] data = trimWav(file, start, end);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+        headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"export.wav\"");
+        return ResponseEntity.ok().headers(headers).body(data);
+    }
+
+    private byte[] trimWav(MultipartFile file, double start, double end) throws IOException, UnsupportedAudioFileException {
+        try (AudioInputStream ais = AudioSystem.getAudioInputStream(file.getInputStream())) {
+            AudioFormat format = ais.getFormat();
+            long startFrame = (long) (start * format.getFrameRate());
+            long endFrame = (long) (end * format.getFrameRate());
+            long framesToCopy = endFrame - startFrame;
+            ais.skip(startFrame * format.getFrameSize());
+            AudioInputStream clipped = new AudioInputStream(ais, format, framesToCopy);
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            AudioSystem.write(clipped, AudioFileFormat.Type.WAVE, baos);
+            return baos.toByteArray();
+        }
+    }
+}

--- a/backend/src/main/java/com/example/backend/AudioController.java
+++ b/backend/src/main/java/com/example/backend/AudioController.java
@@ -1,60 +1,92 @@
 package com.example.backend;
 
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
-import javax.sound.sampled.*;
-import java.io.*;
-import java.util.*;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api")
+@CrossOrigin(origins = "*")
 public class AudioController {
 
+    private final AudioAnalysisService analysisService;
+    private final AudioExportService exportService;
+
+    public AudioController(AudioAnalysisService analysisService, AudioExportService exportService) {
+        this.analysisService = analysisService;
+        this.exportService = exportService;
+    }
+
+    @GetMapping("/health")
+    public Map<String, Object> health() {
+        return Map.of(
+                "status", "ok",
+                "service", "splicepoint-backend",
+                "version", "0.1.0",
+                "engine", "java-sound"
+        );
+    }
+
     @PostMapping("/extract")
-    public Map<String, Object> extract(@RequestParam("file") MultipartFile file) throws Exception {
-        Map<String, Object> result = new HashMap<>();
-        try (AudioInputStream ais = AudioSystem.getAudioInputStream(file.getInputStream())) {
-            AudioFormat format = ais.getFormat();
-            long frames = ais.getFrameLength();
-            double duration = frames / format.getFrameRate();
-            result.put("bpm", 120); // placeholder until analysis added
-            result.put("duration", duration);
-            double loopLen = Math.min(2.0, duration);
-            List<Map<String, Double>> loops = new ArrayList<>();
-            loops.add(Map.of("start", 0.0, "end", loopLen));
-            double start2 = Math.max(0.0, duration / 2 - loopLen / 2);
-            loops.add(Map.of("start", start2, "end", Math.min(duration, start2 + loopLen)));
-            result.put("loops", loops);
+    public ResponseEntity<?> extract(@RequestParam("file") MultipartFile file) {
+        try {
+            validateFile(file);
+            return ResponseEntity.ok(analysisService.analyze(file));
+        } catch (Exception ex) {
+            return ResponseEntity.badRequest().body(error("extract_failed", ex));
         }
-        return result;
     }
 
-    @PostMapping("/export")
-    public ResponseEntity<byte[]> export(@RequestParam("file") MultipartFile file,
-                                         @RequestParam("start") double start,
-                                         @RequestParam("end") double end) throws Exception {
-        byte[] data = trimWav(file, start, end);
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_OCTET_STREAM);
-        headers.set(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"export.wav\"");
-        return ResponseEntity.ok().headers(headers).body(data);
+    @PostMapping(value = "/export", produces = "audio/wav")
+    public ResponseEntity<?> export(@RequestParam("file") MultipartFile file,
+                                    @RequestParam("start") double start,
+                                    @RequestParam("end") double end,
+                                    @RequestParam(value = "fadeMs", defaultValue = "5") int fadeMs) {
+        try {
+            validateFile(file);
+            byte[] data = exportService.exportWav(file, start, end, fadeMs);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.parseMediaType("audio/wav"));
+            headers.setContentLength(data.length);
+            headers.setContentDisposition(ContentDisposition.attachment()
+                    .filename("splicepoint-loop.wav")
+                    .build());
+
+            return ResponseEntity.ok().headers(headers).body(data);
+        } catch (Exception ex) {
+            return ResponseEntity.badRequest().body(error("export_failed", ex));
+        }
     }
 
-    private byte[] trimWav(MultipartFile file, double start, double end) throws IOException, UnsupportedAudioFileException {
-        try (AudioInputStream ais = AudioSystem.getAudioInputStream(file.getInputStream())) {
-            AudioFormat format = ais.getFormat();
-            long startFrame = (long) (start * format.getFrameRate());
-            long endFrame = (long) (end * format.getFrameRate());
-            long framesToCopy = endFrame - startFrame;
-            ais.skip(startFrame * format.getFrameSize());
-            AudioInputStream clipped = new AudioInputStream(ais, format, framesToCopy);
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            AudioSystem.write(clipped, AudioFileFormat.Type.WAVE, baos);
-            return baos.toByteArray();
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("Upload an audio file first.");
         }
+    }
+
+    private Map<String, Object> error(String code, Exception ex) {
+        return Map.of(
+                "code", code,
+                "message", safeMessage(ex)
+        );
+    }
+
+    private String safeMessage(Exception ex) {
+        String message = ex.getMessage();
+        if (message == null || message.isBlank()) {
+            return "SplicePoint could not process this audio file.";
+        }
+        return message;
     }
 }

--- a/backend/src/main/java/com/example/backend/AudioServices.java
+++ b/backend/src/main/java/com/example/backend/AudioServices.java
@@ -1,0 +1,492 @@
+package com.example.backend;
+
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.sound.sampled.AudioFormat;
+import javax.sound.sampled.AudioInputStream;
+import javax.sound.sampled.AudioSystem;
+import javax.sound.sampled.UnsupportedAudioFileException;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+@Service
+class AudioAnalysisService {
+
+    public AnalysisResponse analyze(MultipartFile file) throws IOException, UnsupportedAudioFileException {
+        DecodedAudio audio = AudioDecoder.decode(file);
+        double[] mono = audio.toMono();
+        List<EnergyWindow> windows = AudioMath.energyWindows(mono, audio.sampleRate());
+        List<LoopCandidate> candidates = LoopFinder.findCandidates(mono, audio, windows);
+
+        List<String> warnings = new ArrayList<>();
+        warnings.add("BPM and beat-grid detection are not fully implemented yet; candidates use transient, energy, and boundary heuristics.");
+        warnings.add("Java Sound format support depends on the local runtime; WAV and AIFF are the safest Phase 1 formats.");
+
+        return new AnalysisResponse(
+                safeName(file),
+                file.getContentType(),
+                file.getSize(),
+                AudioMath.round(audio.durationSeconds(), 3),
+                Math.round(audio.sampleRate()),
+                audio.channels(),
+                null,
+                0.0,
+                "phase-1-heuristic",
+                candidates,
+                warnings
+        );
+    }
+
+    private String safeName(MultipartFile file) {
+        String name = file.getOriginalFilename();
+        if (name == null || name.isBlank()) {
+            return "uploaded-audio";
+        }
+        return name;
+    }
+}
+
+@Service
+class AudioExportService {
+
+    public byte[] exportWav(MultipartFile file, double start, double end, int fadeMs)
+            throws IOException, UnsupportedAudioFileException {
+        DecodedAudio audio = AudioDecoder.decode(file);
+        validateSelection(start, end, audio.durationSeconds());
+
+        long startFrame = Math.max(0, Math.round(start * audio.sampleRate()));
+        long endFrame = Math.min(audio.frames(), Math.round(end * audio.sampleRate()));
+        long selectedFrames = endFrame - startFrame;
+
+        if (selectedFrames <= 0) {
+            throw new IllegalArgumentException("Selection is empty. Choose an end time after the start time.");
+        }
+
+        int fadeFrames = (int) Math.min(selectedFrames / 2, Math.max(0, Math.round((fadeMs / 1000.0) * audio.sampleRate())));
+        return WavEncoder.encodePcm16(audio, startFrame, selectedFrames, fadeFrames);
+    }
+
+    private void validateSelection(double start, double end, double duration) {
+        if (!Double.isFinite(start) || !Double.isFinite(end)) {
+            throw new IllegalArgumentException("Start and end must be valid numbers.");
+        }
+        if (start < 0) {
+            throw new IllegalArgumentException("Start time cannot be negative.");
+        }
+        if (end <= start) {
+            throw new IllegalArgumentException("End time must be greater than start time.");
+        }
+        if (start >= duration) {
+            throw new IllegalArgumentException("Start time is outside the uploaded audio duration.");
+        }
+    }
+}
+
+final class AudioDecoder {
+
+    private AudioDecoder() {
+    }
+
+    static DecodedAudio decode(MultipartFile file) throws IOException, UnsupportedAudioFileException {
+        byte[] bytes = file.getBytes();
+        try (AudioInputStream sourceStream = AudioSystem.getAudioInputStream(
+                new BufferedInputStream(new ByteArrayInputStream(bytes)))) {
+
+            AudioFormat sourceFormat = sourceStream.getFormat();
+            if (sourceFormat.getChannels() <= 0 || sourceFormat.getSampleRate() <= 0) {
+                throw new UnsupportedAudioFileException("Audio format is missing channel or sample-rate information.");
+            }
+
+            AudioFormat pcmFormat = new AudioFormat(
+                    AudioFormat.Encoding.PCM_SIGNED,
+                    sourceFormat.getSampleRate(),
+                    16,
+                    sourceFormat.getChannels(),
+                    sourceFormat.getChannels() * 2,
+                    sourceFormat.getSampleRate(),
+                    false
+            );
+
+            try (AudioInputStream pcmStream = AudioSystem.getAudioInputStream(pcmFormat, sourceStream)) {
+                byte[] pcmBytes = pcmStream.readAllBytes();
+                int channels = pcmFormat.getChannels();
+                int frameSize = pcmFormat.getFrameSize();
+                long frames = pcmBytes.length / frameSize;
+                double[][] samples = new double[channels][Math.toIntExact(frames)];
+
+                for (int frame = 0; frame < frames; frame++) {
+                    int frameOffset = frame * frameSize;
+                    for (int channel = 0; channel < channels; channel++) {
+                        int sampleOffset = frameOffset + channel * 2;
+                        int low = pcmBytes[sampleOffset] & 0xff;
+                        int high = pcmBytes[sampleOffset + 1];
+                        short value = (short) ((high << 8) | low);
+                        samples[channel][frame] = value / 32768.0;
+                    }
+                }
+
+                return new DecodedAudio(pcmFormat.getSampleRate(), channels, frames, samples);
+            }
+        } catch (IllegalArgumentException ex) {
+            UnsupportedAudioFileException wrapped = new UnsupportedAudioFileException(
+                    "Unsupported audio encoding. Try WAV or AIFF for the Phase 1 backend."
+            );
+            wrapped.initCause(ex);
+            throw wrapped;
+        }
+    }
+}
+
+record DecodedAudio(float sampleRate, int channels, long frames, double[][] samples) {
+    double durationSeconds() {
+        return frames / sampleRate;
+    }
+
+    double[] toMono() {
+        int length = Math.toIntExact(frames);
+        double[] mono = new double[length];
+        for (int frame = 0; frame < length; frame++) {
+            double sum = 0.0;
+            for (int channel = 0; channel < channels; channel++) {
+                sum += samples[channel][frame];
+            }
+            mono[frame] = sum / channels;
+        }
+        return mono;
+    }
+}
+
+record AnalysisResponse(
+        String fileName,
+        String contentType,
+        long byteSize,
+        double durationSeconds,
+        long sampleRate,
+        int channels,
+        Double bpmEstimate,
+        double bpmConfidence,
+        String engineStatus,
+        List<LoopCandidate> loops,
+        List<String> warnings
+) {
+}
+
+record LoopCandidate(
+        double start,
+        double end,
+        double duration,
+        double confidence,
+        String label,
+        List<String> reasons
+) {
+}
+
+record EnergyWindow(int index, int startFrame, int endFrame, double rms, double transientScore) {
+}
+
+final class LoopFinder {
+
+    private static final int MAX_CANDIDATES = 8;
+
+    private LoopFinder() {
+    }
+
+    static List<LoopCandidate> findCandidates(double[] mono, DecodedAudio audio, List<EnergyWindow> windows) {
+        double duration = audio.durationSeconds();
+        if (duration <= 0.05 || mono.length < 2) {
+            return List.of();
+        }
+
+        List<EnergyWindow> rankedStarts = new ArrayList<>(windows);
+        rankedStarts.sort(Comparator.comparingDouble(EnergyWindow::transientScore).reversed());
+
+        List<Double> loopDurations = loopDurations(duration);
+        List<LoopCandidate> candidates = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+
+        addCandidate(candidates, seen, mono, audio, 0.0, Math.min(duration, loopDurations.getFirst()), "opening slice", 0.18);
+
+        int startLimit = Math.min(24, rankedStarts.size());
+        for (int i = 0; i < startLimit; i++) {
+            double startSeconds = rankedStarts.get(i).startFrame() / audio.sampleRate();
+            for (double loopDuration : loopDurations) {
+                double endSeconds = Math.min(duration, startSeconds + loopDuration);
+                if (endSeconds - startSeconds >= 0.25) {
+                    addCandidate(candidates, seen, mono, audio, startSeconds, endSeconds, "transient candidate", rankedStarts.get(i).transientScore());
+                }
+            }
+        }
+
+        candidates.sort(Comparator.comparingDouble(LoopCandidate::confidence).reversed());
+        if (candidates.size() > MAX_CANDIDATES) {
+            return new ArrayList<>(candidates.subList(0, MAX_CANDIDATES));
+        }
+        return candidates;
+    }
+
+    private static List<Double> loopDurations(double duration) {
+        List<Double> durations = new ArrayList<>();
+        for (double candidate : List.of(1.0, 2.0, 4.0, 8.0)) {
+            if (candidate <= duration) {
+                durations.add(candidate);
+            }
+        }
+        if (durations.isEmpty()) {
+            durations.add(Math.max(0.25, duration));
+        }
+        return durations;
+    }
+
+    private static void addCandidate(List<LoopCandidate> candidates,
+                                     Set<String> seen,
+                                     double[] mono,
+                                     DecodedAudio audio,
+                                     double start,
+                                     double end,
+                                     String label,
+                                     double transientScore) {
+        double roundedStart = AudioMath.round(start, 3);
+        double roundedEnd = AudioMath.round(end, 3);
+        String key = String.format(Locale.ROOT, "%.2f:%.2f", roundedStart, roundedEnd);
+        if (!seen.add(key)) {
+            return;
+        }
+
+        int startFrame = AudioMath.secondsToFrame(start, audio.sampleRate(), mono.length);
+        int endFrame = AudioMath.secondsToFrame(end, audio.sampleRate(), mono.length);
+        if (endFrame <= startFrame) {
+            return;
+        }
+
+        double boundaryCleanliness = AudioMath.boundaryCleanliness(mono, startFrame, endFrame);
+        double energyStability = AudioMath.energyStability(mono, startFrame, endFrame, audio.sampleRate());
+        double durationScore = AudioMath.durationScore(end - start);
+        double confidence = AudioMath.clamp(
+                0.18 + transientScore * 0.32 + boundaryCleanliness * 0.24 + energyStability * 0.18 + durationScore * 0.08,
+                0.05,
+                0.98
+        );
+
+        List<String> reasons = new ArrayList<>();
+        if (transientScore > 0.25) {
+            reasons.add("strong transient near start");
+        }
+        if (boundaryCleanliness > 0.65) {
+            reasons.add("clean boundary estimate");
+        }
+        if (energyStability > 0.55) {
+            reasons.add("stable energy window");
+        }
+        if (durationScore > 0.5) {
+            reasons.add("phase-1 friendly loop length");
+        }
+        if (reasons.isEmpty()) {
+            reasons.add("fallback region candidate");
+        }
+
+        candidates.add(new LoopCandidate(
+                roundedStart,
+                roundedEnd,
+                AudioMath.round(end - start, 3),
+                AudioMath.round(confidence, 3),
+                label,
+                reasons
+        ));
+    }
+}
+
+final class AudioMath {
+
+    private AudioMath() {
+    }
+
+    static List<EnergyWindow> energyWindows(double[] mono, float sampleRate) {
+        int windowSize = Math.max(512, Math.round(sampleRate / 20));
+        int hop = Math.max(256, windowSize / 2);
+        List<EnergyWindow> windows = new ArrayList<>();
+        double previousRms = 0.0;
+        double maxTransient = 0.000001;
+
+        for (int start = 0, index = 0; start < mono.length; start += hop, index++) {
+            int end = Math.min(mono.length, start + windowSize);
+            double rms = rms(mono, start, end);
+            double transientScore = Math.max(0.0, rms - previousRms);
+            maxTransient = Math.max(maxTransient, transientScore);
+            windows.add(new EnergyWindow(index, start, end, rms, transientScore));
+            previousRms = rms * 0.75 + previousRms * 0.25;
+        }
+
+        List<EnergyWindow> normalized = new ArrayList<>();
+        for (EnergyWindow window : windows) {
+            normalized.add(new EnergyWindow(
+                    window.index(),
+                    window.startFrame(),
+                    window.endFrame(),
+                    window.rms(),
+                    clamp(window.transientScore() / maxTransient, 0.0, 1.0)
+            ));
+        }
+        return normalized;
+    }
+
+    static double boundaryCleanliness(double[] mono, int startFrame, int endFrame) {
+        double startLevel = localAbsMean(mono, startFrame, 96);
+        double endLevel = localAbsMean(mono, Math.max(startFrame, endFrame - 1), 96);
+        double risk = Math.min(1.0, (startLevel + endLevel) * 8.0);
+        return clamp(1.0 - risk, 0.0, 1.0);
+    }
+
+    static double energyStability(double[] mono, int startFrame, int endFrame, float sampleRate) {
+        int length = endFrame - startFrame;
+        if (length <= 0) {
+            return 0.0;
+        }
+        int segment = Math.max(256, Math.round(sampleRate / 10));
+        List<Double> values = new ArrayList<>();
+        for (int start = startFrame; start < endFrame; start += segment) {
+            values.add(rms(mono, start, Math.min(endFrame, start + segment)));
+        }
+        if (values.size() < 2) {
+            return 0.5;
+        }
+        double mean = values.stream().mapToDouble(Double::doubleValue).average().orElse(0.0);
+        if (mean <= 0.000001) {
+            return 0.0;
+        }
+        double variance = 0.0;
+        for (double value : values) {
+            double delta = value - mean;
+            variance += delta * delta;
+        }
+        variance /= values.size();
+        double coefficient = Math.sqrt(variance) / mean;
+        return clamp(1.0 - coefficient, 0.0, 1.0);
+    }
+
+    static double durationScore(double duration) {
+        double best = 0.0;
+        for (double target : List.of(1.0, 2.0, 4.0, 8.0)) {
+            double distance = Math.abs(duration - target);
+            best = Math.max(best, 1.0 - Math.min(1.0, distance / target));
+        }
+        return best;
+    }
+
+    static int secondsToFrame(double seconds, float sampleRate, int maxFrames) {
+        return (int) clamp(Math.round(seconds * sampleRate), 0, Math.max(0, maxFrames - 1));
+    }
+
+    static double rms(double[] samples, int start, int end) {
+        if (end <= start) {
+            return 0.0;
+        }
+        double sum = 0.0;
+        for (int i = start; i < end; i++) {
+            sum += samples[i] * samples[i];
+        }
+        return Math.sqrt(sum / (end - start));
+    }
+
+    private static double localAbsMean(double[] samples, int center, int radius) {
+        int start = Math.max(0, center - radius);
+        int end = Math.min(samples.length, center + radius + 1);
+        if (end <= start) {
+            return 1.0;
+        }
+        double sum = 0.0;
+        for (int i = start; i < end; i++) {
+            sum += Math.abs(samples[i]);
+        }
+        return sum / (end - start);
+    }
+
+    static double round(double value, int places) {
+        double factor = Math.pow(10, places);
+        return Math.round(value * factor) / factor;
+    }
+
+    static double clamp(double value, double min, double max) {
+        return Math.max(min, Math.min(max, value));
+    }
+}
+
+final class WavEncoder {
+
+    private WavEncoder() {
+    }
+
+    static byte[] encodePcm16(DecodedAudio audio, long startFrame, long selectedFrames, int fadeFrames) throws IOException {
+        int channels = audio.channels();
+        long dataSize = selectedFrames * channels * 2;
+        if (dataSize > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Selected loop is too large to export in this Phase 1 backend.");
+        }
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream(44 + (int) dataSize);
+        writeAscii(output, "RIFF");
+        writeLittleEndianInt(output, 36 + (int) dataSize);
+        writeAscii(output, "WAVE");
+        writeAscii(output, "fmt ");
+        writeLittleEndianInt(output, 16);
+        writeLittleEndianShort(output, 1);
+        writeLittleEndianShort(output, channels);
+        writeLittleEndianInt(output, Math.round(audio.sampleRate()));
+        writeLittleEndianInt(output, Math.round(audio.sampleRate()) * channels * 2);
+        writeLittleEndianShort(output, channels * 2);
+        writeLittleEndianShort(output, 16);
+        writeAscii(output, "data");
+        writeLittleEndianInt(output, (int) dataSize);
+
+        for (int frame = 0; frame < selectedFrames; frame++) {
+            double gain = fadeGain(frame, selectedFrames, fadeFrames);
+            int sourceFrame = Math.toIntExact(startFrame + frame);
+            for (int channel = 0; channel < channels; channel++) {
+                double value = AudioMath.clamp(audio.samples()[channel][sourceFrame] * gain, -1.0, 1.0);
+                int pcm = (int) Math.round(value * 32767.0);
+                writeLittleEndianShort(output, pcm);
+            }
+        }
+
+        return output.toByteArray();
+    }
+
+    private static double fadeGain(long frame, long selectedFrames, int fadeFrames) {
+        if (fadeFrames <= 0) {
+            return 1.0;
+        }
+        double gain = 1.0;
+        if (frame < fadeFrames) {
+            gain = Math.min(gain, frame / (double) fadeFrames);
+        }
+        long framesFromEnd = selectedFrames - frame - 1;
+        if (framesFromEnd < fadeFrames) {
+            gain = Math.min(gain, framesFromEnd / (double) fadeFrames);
+        }
+        return AudioMath.clamp(gain, 0.0, 1.0);
+    }
+
+    private static void writeAscii(ByteArrayOutputStream output, String value) throws IOException {
+        output.write(value.getBytes(java.nio.charset.StandardCharsets.US_ASCII));
+    }
+
+    private static void writeLittleEndianInt(ByteArrayOutputStream output, int value) {
+        output.write(value & 0xff);
+        output.write((value >> 8) & 0xff);
+        output.write((value >> 16) & 0xff);
+        output.write((value >> 24) & 0xff);
+    }
+
+    private static void writeLittleEndianShort(ByteArrayOutputStream output, int value) {
+        output.write(value & 0xff);
+        output.write((value >> 8) & 0xff);
+    }
+}

--- a/backend/src/main/java/com/example/backend/BackendApplication.java
+++ b/backend/src/main/java/com/example/backend/BackendApplication.java
@@ -1,0 +1,13 @@
+package com.example.backend;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class BackendApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(BackendApplication.class, args);
+	}
+
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=backend

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,4 @@
-spring.application.name=backend
+spring.application.name=splicepoint-backend
+server.port=8080
+spring.servlet.multipart.max-file-size=100MB
+spring.servlet.multipart.max-request-size=100MB

--- a/backend/src/test/java/com/example/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/example/backend/BackendApplicationTests.java
@@ -1,0 +1,13 @@
+package com.example.backend;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class BackendApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/backend/src/test/java/com/example/backend/BackendApplicationTests.java
+++ b/backend/src/test/java/com/example/backend/BackendApplicationTests.java
@@ -2,12 +2,90 @@ package com.example.backend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 class BackendApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
+    @Test
+    void analyzesSimpleWavFile() throws Exception {
+        MockMultipartFile file = testWavFile();
+        AudioAnalysisService service = new AudioAnalysisService();
+
+        AnalysisResponse response = service.analyze(file);
+
+        assertThat(response.durationSeconds()).isGreaterThan(0.9).isLessThan(1.1);
+        assertThat(response.sampleRate()).isEqualTo(44_100);
+        assertThat(response.channels()).isEqualTo(1);
+        assertThat(response.loops()).isNotEmpty();
+    }
+
+    @Test
+    void exportsSelectedWavLoop() throws Exception {
+        MockMultipartFile file = testWavFile();
+        AudioExportService service = new AudioExportService();
+
+        byte[] exported = service.exportWav(file, 0.0, 0.5, 5);
+
+        assertThat(exported).hasSizeGreaterThan(44);
+        assertThat(new String(exported, 0, 4)).isEqualTo("RIFF");
+        assertThat(new String(exported, 8, 4)).isEqualTo("WAVE");
+    }
+
+    private MockMultipartFile testWavFile() throws IOException {
+        int sampleRate = 44_100;
+        int seconds = 1;
+        int channels = 1;
+        int bitsPerSample = 16;
+        int totalSamples = sampleRate * seconds;
+        int dataSize = totalSamples * channels * bitsPerSample / 8;
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream(44 + dataSize);
+        writeAscii(output, "RIFF");
+        writeLittleEndianInt(output, 36 + dataSize);
+        writeAscii(output, "WAVE");
+        writeAscii(output, "fmt ");
+        writeLittleEndianInt(output, 16);
+        writeLittleEndianShort(output, 1);
+        writeLittleEndianShort(output, channels);
+        writeLittleEndianInt(output, sampleRate);
+        writeLittleEndianInt(output, sampleRate * channels * bitsPerSample / 8);
+        writeLittleEndianShort(output, channels * bitsPerSample / 8);
+        writeLittleEndianShort(output, bitsPerSample);
+        writeAscii(output, "data");
+        writeLittleEndianInt(output, dataSize);
+
+        for (int i = 0; i < totalSamples; i++) {
+            double envelope = i < 256 ? i / 256.0 : 1.0;
+            double sample = Math.sin(2.0 * Math.PI * 220.0 * i / sampleRate) * envelope * 0.35;
+            writeLittleEndianShort(output, (int) Math.round(sample * 32767.0));
+        }
+
+        return new MockMultipartFile("file", "test.wav", "audio/wav", output.toByteArray());
+    }
+
+    private void writeAscii(ByteArrayOutputStream output, String value) throws IOException {
+        output.write(value.getBytes(java.nio.charset.StandardCharsets.US_ASCII));
+    }
+
+    private void writeLittleEndianInt(ByteArrayOutputStream output, int value) {
+        output.write(value & 0xff);
+        output.write((value >> 8) & 0xff);
+        output.write((value >> 16) & 0xff);
+        output.write((value >> 24) & 0xff);
+    }
+
+    private void writeLittleEndianShort(ByteArrayOutputStream output, int value) {
+        output.write(value & 0xff);
+        output.write((value >> 8) & 0xff);
+    }
 }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,6 +1,10 @@
 let wavesurfer;
 let regionsPlugin;
 let currentFile;
+let selectedRegion;
+let currentAnalysis;
+
+const API_BASE = window.location.protocol === 'file:' ? 'http://localhost:8080' : '';
 
 function init() {
   wavesurfer = WaveSurfer.create({
@@ -26,86 +30,266 @@ function init() {
   const fileInput = document.getElementById('fileInput');
 
   drop.addEventListener('click', () => fileInput.click());
-  drop.addEventListener('dragover', (e) => {
-    e.preventDefault();
+  drop.addEventListener('dragover', (event) => {
+    event.preventDefault();
     drop.classList.add('dragover');
   });
   drop.addEventListener('dragleave', () => drop.classList.remove('dragover'));
-  drop.addEventListener('drop', (e) => {
-    e.preventDefault();
+  drop.addEventListener('drop', (event) => {
+    event.preventDefault();
     drop.classList.remove('dragover');
-    handleFiles(e.dataTransfer.files);
+    handleFiles(event.dataTransfer.files);
   });
-  fileInput.addEventListener('change', (e) => handleFiles(e.target.files));
+  fileInput.addEventListener('change', (event) => handleFiles(event.target.files));
 
-  regionsPlugin.on('region-click', (region, e) => {
-    e.stopPropagation();
+  regionsPlugin.on('region-click', (region, event) => {
+    event.stopPropagation();
+    selectRegion(region);
     region.playLoop();
   });
+
+  setStatus('Ready. Drop an audio file to begin.');
 }
 
 async function handleFiles(files) {
   if (!files.length) return;
+
   const file = files[0];
-  if (!file.type.startsWith('audio')) return;
+  if (!file.type.startsWith('audio')) {
+    setStatus('Unsupported file type. Upload an audio file.', true);
+    return;
+  }
+
   currentFile = file;
+  selectedRegion = null;
+  currentAnalysis = null;
+  clearCandidateList();
+  clearRegions();
+
+  setStatus('Loading waveform and analyzing audio...');
+
+  const readyPromise = new Promise((resolve) => wavesurfer.once('ready', resolve));
   wavesurfer.loadBlob(file);
 
-  const formData = new FormData();
-  formData.append('file', file);
   try {
-    const res = await fetch('/api/extract', {
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const response = await fetch(`${API_BASE}/api/extract`, {
       method: 'POST',
       body: formData
     });
-    if (res.ok) {
-      const data = await res.json();
-      wavesurfer.once('ready', () => showSuggestedLoops(data.loops));
+
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.message || 'Analysis failed.');
     }
-  } catch (e) {
-    console.error(e);
+
+    currentAnalysis = data;
+    await readyPromise;
+    showSuggestedLoops(data.loops || []);
+    renderAnalysis(data);
+    setStatus(`Analysis ready: ${formatDuration(data.durationSeconds)} seconds, ${data.loops?.length || 0} loop candidates.`);
+  } catch (error) {
+    await readyPromise.catch(() => {});
+    setStatus(error.message || 'Could not analyze this file.', true);
+    showFallbackLoop();
   }
 }
 
 function showSuggestedLoops(loops) {
-  regionsPlugin.clearRegions();
-  loops.forEach(({ start, end }) =>
-    regionsPlugin.addRegion({
-      start,
-      end,
-      color: 'rgba(0, 255, 0, 0.1)',
-      drag: false,
-      resize: false
-    })
-  );
+  clearRegions();
+  loops.forEach((candidate, index) => {
+    const region = regionsPlugin.addRegion({
+      start: candidate.start,
+      end: candidate.end,
+      color: index === 0 ? 'rgba(0, 180, 255, 0.18)' : 'rgba(0, 255, 0, 0.12)',
+      drag: true,
+      resize: true
+    });
+
+    region.splicePointCandidate = candidate;
+    if (index === 0) {
+      selectRegion(region);
+    }
+  });
+  renderCandidates(loops);
+}
+
+function showFallbackLoop() {
+  clearRegions();
+  const duration = wavesurfer.getDuration();
+  if (!Number.isFinite(duration) || duration <= 0) return;
+
+  const region = regionsPlugin.addRegion({
+    start: 0,
+    end: Math.min(2, duration),
+    color: 'rgba(255, 180, 0, 0.18)',
+    drag: true,
+    resize: true
+  });
+  selectRegion(region);
 }
 
 async function exportSelection() {
-  if (!currentFile) return;
-  const regions = Object.values(regionsPlugin.regions);
-  if (!regions.length) return;
-  const { start, end } = regions[0];
-  const formData = new FormData();
-  formData.append('file', currentFile);
-  formData.append('start', start);
-  formData.append('end', end);
-
-  const res = await fetch('/api/export', {
-    method: 'POST',
-    body: formData
-  });
-
-  if (res.ok) {
-    const blob = await res.blob();
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'export.wav';
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(url);
+  if (!currentFile) {
+    setStatus('Upload an audio file before exporting.', true);
+    return;
   }
+
+  const region = selectedRegion || getRegionList()[0];
+  if (!region) {
+    setStatus('Choose or create a loop region before exporting.', true);
+    return;
+  }
+
+  const start = Number(region.start);
+  const end = Number(region.end);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end <= start) {
+    setStatus('Selected region is invalid. Adjust the start and end points.', true);
+    return;
+  }
+
+  setStatus(`Exporting ${formatDuration(end - start)} second loop...`);
+
+  try {
+    const formData = new FormData();
+    formData.append('file', currentFile);
+    formData.append('start', start);
+    formData.append('end', end);
+    formData.append('fadeMs', 5);
+
+    const response = await fetch(`${API_BASE}/api/export`, {
+      method: 'POST',
+      body: formData
+    });
+
+    if (!response.ok) {
+      let message = 'Export failed.';
+      try {
+        const error = await response.json();
+        message = error.message || message;
+      } catch (_) {
+        // Keep fallback message when server did not return JSON.
+      }
+      throw new Error(message);
+    }
+
+    const blob = await response.blob();
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = buildExportName(start, end);
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+    setStatus('Export complete. WAV loop downloaded.');
+  } catch (error) {
+    setStatus(error.message || 'Could not export the selected loop.', true);
+  }
+}
+
+function selectRegion(region) {
+  selectedRegion = region;
+  const duration = region.end - region.start;
+  document.getElementById('selection').textContent =
+    `Selected: ${formatDuration(region.start)}s → ${formatDuration(region.end)}s (${formatDuration(duration)}s)`;
+}
+
+function clearRegions() {
+  if (regionsPlugin?.clearRegions) {
+    regionsPlugin.clearRegions();
+  }
+  selectedRegion = null;
+  document.getElementById('selection').textContent = 'Selected: none';
+}
+
+function getRegionList() {
+  if (regionsPlugin?.getRegions) {
+    return regionsPlugin.getRegions();
+  }
+  return Object.values(regionsPlugin?.regions || {});
+}
+
+function renderAnalysis(data) {
+  const details = document.getElementById('analysis');
+  details.innerHTML = `
+    <strong>${escapeHtml(data.fileName || 'uploaded audio')}</strong><br />
+    Duration: ${formatDuration(data.durationSeconds)}s<br />
+    Sample rate: ${data.sampleRate || 'unknown'} Hz<br />
+    Channels: ${data.channels || 'unknown'}<br />
+    Engine: ${escapeHtml(data.engineStatus || 'unknown')}
+  `;
+
+  const warnings = data.warnings || [];
+  document.getElementById('warnings').innerHTML = warnings
+    .map((warning) => `<li>${escapeHtml(warning)}</li>`)
+    .join('');
+}
+
+function renderCandidates(loops) {
+  const list = document.getElementById('candidates');
+  if (!loops.length) {
+    list.innerHTML = '<li>No loop candidates returned.</li>';
+    return;
+  }
+
+  list.innerHTML = loops.map((candidate, index) => {
+    const reasons = (candidate.reasons || []).map(escapeHtml).join(', ');
+    return `
+      <li>
+        <button type="button" data-candidate-index="${index}">
+          ${escapeHtml(candidate.label || 'candidate')} · ${formatDuration(candidate.start)}s → ${formatDuration(candidate.end)}s · confidence ${Math.round((candidate.confidence || 0) * 100)}%
+        </button>
+        <small>${reasons}</small>
+      </li>
+    `;
+  }).join('');
+
+  list.querySelectorAll('button[data-candidate-index]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const region = getRegionList()[Number(button.dataset.candidateIndex)];
+      if (region) {
+        selectRegion(region);
+        region.playLoop();
+      }
+    });
+  });
+}
+
+function clearCandidateList() {
+  document.getElementById('analysis').textContent = 'No analysis yet.';
+  document.getElementById('warnings').innerHTML = '';
+  document.getElementById('candidates').innerHTML = '';
+}
+
+function setStatus(message, isError = false) {
+  const status = document.getElementById('status');
+  status.textContent = message;
+  status.classList.toggle('error', isError);
+}
+
+function buildExportName(start, end) {
+  const base = (currentFile?.name || 'splicepoint-loop')
+    .replace(/\.[^.]+$/, '')
+    .replace(/[^a-z0-9-_]+/gi, '_')
+    .replace(/^_+|_+$/g, '') || 'splicepoint-loop';
+  return `${base}_${formatDuration(start)}s-${formatDuration(end)}s.wav`;
+}
+
+function formatDuration(value) {
+  if (!Number.isFinite(Number(value))) return '0.000';
+  return Number(value).toFixed(3);
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>SplicePoint</title>
   <link rel="stylesheet" href="styles.css" />
   <script src="https://unpkg.com/wavesurfer.js@7/dist/wavesurfer.min.js"></script>
@@ -9,18 +10,47 @@
   <script src="https://unpkg.com/wavesurfer.js@7/dist/plugins/timeline.min.js"></script>
 </head>
 <body>
-  <div id="drop" class="drop">
-    Drop audio here or click to upload
-    <input type="file" id="fileInput" accept="audio/*" hidden />
-  </div>
-  <div id="waveform"></div>
-  <div id="timeline"></div>
-  <div class="controls">
-    <button id="play">Play</button>
-    <button id="pause">Pause</button>
-    <button id="stop">Stop</button>
-    <button id="export">Export</button>
-  </div>
+  <main class="app-shell">
+    <header class="hero">
+      <p class="eyebrow">Phase 1 Prototype</p>
+      <h1>SplicePoint</h1>
+      <p>Upload audio, inspect candidate splice regions, audition loops, and export the selected WAV slice.</p>
+    </header>
+
+    <section class="panel upload-panel">
+      <div id="drop" class="drop">
+        Drop audio here or click to upload
+        <input type="file" id="fileInput" accept="audio/*" hidden />
+      </div>
+      <p id="status" class="status">Initializing...</p>
+    </section>
+
+    <section class="panel waveform-panel">
+      <div id="waveform"></div>
+      <div id="timeline"></div>
+      <div class="controls">
+        <button id="play" type="button">Play</button>
+        <button id="pause" type="button">Pause</button>
+        <button id="stop" type="button">Stop</button>
+        <button id="export" type="button">Export Selected WAV</button>
+      </div>
+      <p id="selection" class="selection">Selected: none</p>
+    </section>
+
+    <section class="grid">
+      <article class="panel">
+        <h2>Analysis</h2>
+        <p id="analysis">No analysis yet.</p>
+        <ul id="warnings" class="warnings"></ul>
+      </article>
+
+      <article class="panel">
+        <h2>Loop Candidates</h2>
+        <ol id="candidates" class="candidates"></ol>
+      </article>
+    </section>
+  </main>
+
   <script src="app.js"></script>
 </body>
 </html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,32 +1,204 @@
+:root {
+  color-scheme: dark;
+  --bg: #0b0f17;
+  --panel: #141b27;
+  --panel-soft: #192232;
+  --ink: #eef5ff;
+  --muted: #91a0b6;
+  --accent: #5dd7ff;
+  --accent-2: #8cffc7;
+  --danger: #ff7b7b;
+  --line: #293448;
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
-  font-family: sans-serif;
-  margin: 20px;
+  margin: 0;
+  min-height: 100vh;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at top left, rgba(93, 215, 255, 0.16), transparent 30rem),
+    radial-gradient(circle at bottom right, rgba(140, 255, 199, 0.08), transparent 28rem),
+    var(--bg);
 }
 
-#waveform {
-  height: 128px;
-  margin-top: 10px;
+.app-shell {
+  width: min(1120px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 40px 0;
 }
 
-#timeline {
-  height: 20px;
+.hero {
+  margin-bottom: 24px;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--accent-2);
+  font-size: 0.8rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 8px;
+  font-size: clamp(2.5rem, 8vw, 5rem);
+  line-height: 0.9;
+}
+
+h2 {
+  margin-bottom: 12px;
+  font-size: 1rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hero p:last-child,
+.status,
+.selection,
+#analysis,
+.warnings,
+.candidates small {
+  color: var(--muted);
+}
+
+.panel {
+  border: 1px solid var(--line);
+  border-radius: 18px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.015)), var(--panel);
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.26);
+  padding: 20px;
+}
+
+.upload-panel,
+.waveform-panel {
+  margin-bottom: 18px;
 }
 
 .drop {
-  border: 2px dashed #aaa;
-  padding: 20px;
+  border: 2px dashed rgba(93, 215, 255, 0.42);
+  border-radius: 16px;
+  padding: 32px 20px;
   text-align: center;
   cursor: pointer;
+  background: rgba(93, 215, 255, 0.05);
+  transition: border-color 150ms ease, background 150ms ease, transform 150ms ease;
 }
 
+.drop:hover,
 .drop.dragover {
-  border-color: #555;
+  border-color: var(--accent);
+  background: rgba(93, 215, 255, 0.12);
+  transform: translateY(-1px);
+}
+
+.status {
+  margin: 12px 0 0;
+}
+
+.status.error {
+  color: var(--danger);
+}
+
+#waveform {
+  min-height: 132px;
+  margin-top: 4px;
+  border-radius: 12px;
+  background: #0e1420;
+  overflow: hidden;
+}
+
+#timeline {
+  min-height: 24px;
+  margin-top: 8px;
 }
 
 .controls {
-  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 14px;
 }
 
-.controls button {
-  margin-right: 5px;
+button {
+  border: 1px solid rgba(93, 215, 255, 0.34);
+  border-radius: 999px;
+  padding: 10px 14px;
+  color: var(--ink);
+  background: var(--panel-soft);
+  cursor: pointer;
+  font-weight: 700;
+}
+
+button:hover {
+  border-color: var(--accent);
+}
+
+#export {
+  background: linear-gradient(90deg, rgba(93, 215, 255, 0.2), rgba(140, 255, 199, 0.14)), var(--panel-soft);
+}
+
+.selection {
+  margin: 12px 0 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.85fr) minmax(0, 1.15fr);
+  gap: 18px;
+}
+
+.warnings {
+  margin: 12px 0 0;
+  padding-left: 20px;
+}
+
+.warnings li + li,
+.candidates li + li {
+  margin-top: 8px;
+}
+
+.candidates {
+  margin: 0;
+  padding-left: 22px;
+}
+
+.candidates li {
+  padding: 10px 0;
+}
+
+.candidates button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  border-radius: 12px;
+}
+
+.candidates small {
+  display: block;
+  margin-top: 6px;
+  line-height: 1.4;
+}
+
+@media (max-width: 760px) {
+  .app-shell {
+    width: min(100% - 20px, 1120px);
+    padding: 24px 0;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
 }


### PR DESCRIPTION
## Summary
- scaffold Spring Boot backend with placeholder analysis and WAV export endpoints
- hook frontend into new /api/extract and /api/export routes
- document backend usage and endpoints

## Testing
- `./backend/mvnw -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ef1da744832d805fe2b0c6a5420a